### PR TITLE
Removing tool_proxy_guid assignment on deployment_request object.

### DIFF
--- a/lti2_tc/app/models/lti2_tc/tool_registration.rb
+++ b/lti2_tc/app/models/lti2_tc/tool_registration.rb
@@ -24,7 +24,6 @@ module Lti2Tc
       # Only comment out to test old-style ('late') tool_proxy_guid creation
       tool_proxy_guid = UUID.generate
 
-      deployment_request.tool_proxy_guid = tool_proxy_guid
       deployment_request.status = 'submitted'
       deployment_request.save
 


### PR DESCRIPTION
Hiya,

Attempts to call 

    Lti2Tc::ToolRegistration.register_tool

with a valid `deployment_request`

are met with the error:


    undefined method `tool_proxy_guid=' for #<Lti2Tc::DeploymentRequest:0x007ff216809e58>
    
    /apps/LTI2-Reference/lti2_tc/app/models/lti2_tc/tool_registration.rb:27:in `register_tool'
    app/admin/register_new_tool.rb:26:in `block (2 levels) in <top (required)>'
    /apps/tmp/vendor/bundle/ruby/2.1.0/bundler/gems/active_admin-e3a7354c0196/lib/active_admin/views/pages/page.rb:8:in `instance_exec'
    ...