### PR TITLE
Migrations fixes for lti2_tp

### DIFF
--- a/lti2_tp/db/migrate/20151111000001_reload_tp_db.rb
+++ b/lti2_tp/db/migrate/20151111000001_reload_tp_db.rb
@@ -62,5 +62,6 @@ class ReloadTpDb < ActiveRecord::Migration
     drop_table :lti2_tp_registrations
     drop_table :lti2_tp_registries
     drop_table :lti2_tp_tools
+    drop_table :lti_registration_wips
   end
 end

--- a/lti2_tp/db/migrate/20151111000001_reload_tp_db.rb
+++ b/lti2_tp/db/migrate/20151111000001_reload_tp_db.rb
@@ -1,4 +1,4 @@
-class CreateLti2TpResources < ActiveRecord::Migration
+class ReloadTpDb < ActiveRecord::Migration
   def up
     create_table "lti2_tp_registrations", force: true do |t|
       t.integer  "tenant_id"


### PR DESCRIPTION
There were two issues with the lti2_tp migration:

1) The migration's file name differed from its class name. Rails refuses to run the migration unless these two names match.

2) The migration's down method wasn't dropping one of the tables it created.

These two issues are now fixed. Let me know if you disagree with anything or if anything else in the project needs to change as a result of the above changes.

Cheers,
Ranko