### PR TITLE
Remove rails version

### DIFF
--- a/lti2.gemspec
+++ b/lti2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
 
   # lti2 commons
   s.add_runtime_dependency 'oauth', '~> 0.4.7'

--- a/lti2_tc/app/controllers/lti2_tc/tools_controller.rb
+++ b/lti2_tc/app/controllers/lti2_tc/tools_controller.rb
@@ -76,6 +76,8 @@ module Lti2Tc
 
       resource_nodes = tool_proxy_wrapper.first_at('tool_profile.resource_handler')
 
+      # TODO: Move this resource creation code to LTI2_tc_sample_app
+      
       # course 2(SMPL101), 11 & 12 DEP from conformance test
       target_courses = [2, 5, 6]
       for resource_node in resource_nodes

--- a/lti2_tc/lti2_tc.gemspec
+++ b/lti2_tc/lti2_tc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0.0'
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
   s.add_dependency 'mysql2', '~> 0.3.13'
 
   s.add_development_dependency 'sqlite3'

--- a/lti2_tp/app/models/lti2_tp/tool_provider_registry.rb
+++ b/lti2_tp/app/models/lti2_tp/tool_provider_registry.rb
@@ -3,17 +3,68 @@ module Lti2Tp
   class ToolProviderRegistry
 
     attr_reader :security_contract_template, :tp_deployment_url, :relaxed_oauth_check, :result_template,
-                :tool_provider_name, :registry
+      :tool_provider_name, :registry
 
     def initialize
-      registry_entries = Registry.all()
+      registry_entries = [
+        OpenStruct.new(name: 'tp_deployment_url', content: 'http://localhost:3000'),
+        OpenStruct.new(name: 'security_contract_template', content: security_contract_template),
+        OpenStruct.new(name: 'relaxed_oauth_check', content: 'false'),
+        OpenStruct.new(name: 'result_template', content: result_template),
+        OpenStruct.new(name: 'tool_provider_name', content: 'Fabericious'),
+        OpenStruct.new(name: 'wirelog_filename', content: '/tmp/wirelog.html'),
+      ]
+
       @registry = {}
-      registry_entries.each { |entry| @registry[entry.name] = entry.content unless entry.name == 'content' }
+      registry_entries.each {|entry| @registry[entry.name] = entry.content unless entry.name == 'content'}
 
       @tp_deployment_url = registry['tp_deployment_url']
       @relaxed_oauth_check = registry['relaxed_oauth_check']
       @result_template = registry['result_template']
       @tool_provider_name = registry['tool_provider_name']
+    end
+
+    def security_contract_template
+      <<-text
+{ "shared_secret" : "{aSecret}",
+  "tool_service" : [ {
+	"@id": ":ToolProxy.collection",
+	"@type" : "RestServiceProfile",
+        "action" : "POST",
+        "service" : "http://lms.example.com/profile/b6ffa601-ce1d-4549-9ccf-145670a964d4#ToolProxy.collection"
+      },
+      {
+	"@id": ":ToolProxy.item",
+	"@type" : "RestServiceProfile",
+        "action" : [ "GET",
+            "PUT"
+          ],
+        "service" : "http://lms.example.com/profile/b6ffa601-ce1d-4549-9ccf-145670a964d4#ToolProxy.item"
+      },
+      {
+	"@id": ":ToolProxy.collection",
+	"@type" : "RestService",
+        "action" : [ "GET",
+            "PUT"
+          ],
+        "service" : "http://lms.example.com/profile/b6ffa601-ce1d-4549-9ccf-145670a964d4#Result.item"
+      }
+    ]
+}
+      text
+    end
+
+    def result_template
+      <<-text
+{
+  "@context" : "http://www.imsglobal.org/imspurl/lis/v2/ctx/Result",
+  "@type" : "Result",
+  "resultScore" : {
+    "@type" : "decimal",
+    "@value"  : {value}
+  }
+}
+      text
     end
 
   end

--- a/lti2_tp/config/initializers/lti2_tp.rb
+++ b/lti2_tp/config/initializers/lti2_tp.rb
@@ -1,11 +1,8 @@
 include Lti2Commons
 include WireLogSupport
 
-NONCE_TIME_TO_LIVE = 300  # seconds
+NONCE_TIME_TO_LIVE = 300 # seconds
 Rails.application.config.nonce_cache = Cache.new :ttl => NONCE_TIME_TO_LIVE
 
-if ActiveRecord::Base.connection.table_exists? 'lti2_tp_registries'
-  Rails.application.config.tool_provider_registry = Lti2Tp::ToolProviderRegistry.new
-end
-
+Rails.application.config.tool_provider_registry = Lti2Tp::ToolProviderRegistry.new
 Rails.application.config.wire_log = WireLog.new "ToolProvider", File.expand_path("../tc_sample_app/public/wirelog.html")

--- a/lti2_tp/lti2_tp.gemspec
+++ b/lti2_tp/lti2_tp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0.0'
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
   s.add_dependency 'mysql2', '~> 0.3.13'
 
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This pulls in the commits from the origin that removed the rails version. It does appear to include some other items as well though. Are these additional changes a blocker? If so we can just extract out the rails version changes as our own commit.